### PR TITLE
remove inc::Module::Install from cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,3 @@
-use inc::Module::Install;
-    
 requires 'Pod::Text::Color::Delight';
 requires 'Carp::Always::Color::Term';
 requires 'Data::Dump::Color';


### PR DESCRIPTION
we don't *need* this in a cpanfile, it just causes confusion and
prevents the cpanfile from working with cpanm

note, the dependency chain fails here as Test::Block doesn't work
with perl5.24+[1]:

    --> Working on .
    Configuring /Volumes/code_partition/perlcolour ... OK
    ==> Found dependencies: Data::HexDump::Range
    --> Working on Data::HexDump::Range
    Fetching http://www.cpan.org/authors/id/N/NK/NKH/Data-HexDump-Range-0.13.72.tar.gz ... OK
    Configuring Data-HexDump-Range-v0.13.72 ... OK
    ==> Found dependencies: Term::Bash::Completion::Generator, Text::Colorizer, Test::Block
    --> Working on Term::Bash::Completion::Generator
    Fetching http://www.cpan.org/authors/id/N/NK/NKH/Term-Bash-Completion-Generator-0.02.8.tar.gz ... OK
    Configuring Term-Bash-Completion-Generator-0.02.8 ... OK
    ==> Found dependencies: Test::Block
    --> Working on Test::Block
    Fetching http://www.cpan.org/authors/id/A/AD/ADIE/Test-Block-0.13.tar.gz ... OK
    Configuring Test-Block-0.13 ... OK
    Building and testing Test-Block-0.13 ... FAIL
    ! Installing Test::Block failed. See /Users/leejohnson/.cpanm/work/1479972414.52133/build.log for details. Retry with --force to force install it.
    ! Installing the dependencies failed: Module 'Test::Block' is not installed
    ! Bailing out the installation for Term-Bash-Completion-Generator-0.02.8.
    --> Working on Text::Colorizer
    Fetching http://www.cpan.org/authors/id/N/NK/NKH/Text-Colorizer-0.03.tar.gz ... OK
    Configuring Text-Colorizer-0.03 ... OK
    ==> Found dependencies: Test::Block
    ! Installing the dependencies failed: Module 'Test::Block' is not installed
    ! Bailing out the installation for Text-Colorizer-0.03.
    ! Installing the dependencies failed: Module 'Test::Block' is not installed, Module 'Term::Bash::Completion::Generator' is not installed, Module 'Text::Colorizer' is not installed
    ! Bailing out the installation for Data-HexDump-Range-v0.13.72.
    ! Installing the dependencies failed: Module 'Data::HexDump::Range' is not installed
    ! Bailing out the installation for ..

[1] https://rt.cpan.org/Public/Bug/Display.html?id=112462 in which
we see that changes in 5.23.8 caused this (now deprecated) module
to break:

    From cb65aada4214c7ba701e2ea46ba4a17dc12a4025 Mon Sep 17 00:00:00 2001
    From: David Mitchell <davem@iabyn.com>
    Date: Fri, 26 Feb 2016 16:40:30 +0000
    Subject: [PATCH] Make Test-Block work with perl 5.23.8+

    In 5.23.8, the order of steps that perl takes when leaving a scope has
    changed. In particular, destructors are now called *before* PL_curcop
    is restored and before the context is popped from the stack.

    The net effect of this is that caller() called from a destructor called
    while exiting a scope will see the last line of the exiting scope rather
    than its first line, and may see STOREs still in the call stack that
    were triggered by undoing a locations of a tied variable, that themselves
    trigger destructors.
    ---
     Test-Block-0.13/lib/Test/Block.pm | 16 ++++++++++++++++
     Test-Block-0.13/t/block.t         | 10 +++++++---
     2 files changed, 23 insertions(+), 3 deletions(-)

    diff --git a/Test-Block-0.13/lib/Test/Block.pm b/Test-Block-0.13/lib/Test/Block.pm
    index 1598ea7..3e1b029 100644
    --- a/Test-Block-0.13/lib/Test/Block.pm
    +++ b/Test-Block-0.13/lib/Test/Block.pm
    @@ -59,6 +59,22 @@ sub DESTROY {
	 my $name = $self->{name};
	 my $tests_ran = _tests_run_in_block($self);
	 $name = "'$name'" unless looks_like_number( $name );
    +
    +    # In perl 5.23.7 and earlier, the call stack at this point looks like:
    +    #
    +    #     Test::Block::DESTROY(...)     called at test_script line NNN
    +    #     eval {...}                    called at test_script line NNN
    +    #
    +    # in perl 5.23.8 and later, like:
    +    #
    +    #     Test::Block::DESTROY(...)     called at Tie/Scalar.pm line 157
    +    #     eval {...}                    called at Tie/Scalar.pm line 157
    +    #     Tie::StdScalar::STORE(...)    called at Test/Block.pm line 96
    +    #     Test::Block::Plan::STORE(...) called at test_script line NNN
    +    #
    +    local $Test::Builder::Level =
    +        $Test::Builder::Level + ($] >= 5.023008 ? 3 : 0);
    +
	 $Test_builder->ok(
	     0,
	     "block $name expected $expected test(s) and ran $tests_ran"
    diff --git a/Test-Block-0.13/t/block.t b/Test-Block-0.13/t/block.t
    index fbf8469..4a9f814 100644
    --- a/Test-Block-0.13/t/block.t
    +++ b/Test-Block-0.13/t/block.t
    @@ -4,6 +4,10 @@ use Test::Builder::Tester tests => 6;
     use Test::More;
     use Test::Block;

    +# in perl 5.23.8 and later, caller() in a destructor called while
    +# exiting a block shows the last line of the block, not the first
    +my $lastl = $] >= 5.023008;
    +
     test_out('ok 1');
     {
	 my $block = Test::Block->plan(1);
    @@ -14,7 +18,7 @@ test_test("count okay");

     test_out('ok 1');
     test_out('not ok 2 - block 2 expected 2 test(s) and ran 1');
    -test_fail(+2);
    +test_fail($lastl ? +3 : +2);
     {
	 my $block = Test::Block->plan(2);
	 ok(1);
    @@ -25,7 +29,7 @@ test_test("too few tests");
     test_out('ok 1');
     test_out('ok 2');
     test_out('not ok 3 - block 3 expected 1 test(s) and ran 2');
    -test_fail(+2);
    +test_fail($lastl ? +4 : +2);
     {
	 my $block = Test::Block->plan(1);
	 ok(1);
    @@ -57,7 +61,7 @@ test_test("nested blocks");

     test_out('ok 1');
     test_out("not ok 2 - block 'foo' expected 2 test(s) and ran 1");
    -test_fail(+2);
    +test_fail($lastl ? +3 : +2);
     {
	 my $block = Test::Block->plan(foo => 2);
	 ok(1);
    --
    2.4.3